### PR TITLE
Duplicate cookie support

### DIFF
--- a/js/cookieparser.js
+++ b/js/cookieparser.js
@@ -139,9 +139,9 @@ CookieParser.prototype.parse = function CookieParser$parse(str) {
                     var key = this.extract(str, keyStart, keyEnd);
                     var value = this.extract(str, valueStart, valueEnd);
 
-                    dictionary[key] = valueMightNeedDecoding
-                        ? this.decode(value)
-                        : value;
+                    var pvalue = dictionary[key];
+                    var nvalue = valueMightNeedDecoding ? this.decode(value) : value;
+                    dictionary[key] = (pvalue instanceof Array) ? (pvalue[pvalue.length] = nvalue) : (pvalue ? [pvalue, nvalue] : nvalue);
 
                     i = j;
                     for (; j < len; ++j) {
@@ -169,9 +169,9 @@ CookieParser.prototype.parse = function CookieParser$parse(str) {
             var key = this.extract(str, keyStart, keyEnd);
             var value = this.extract(str, valueStart, valueEnd);
 
-            dictionary[key] = valueMightNeedDecoding
-                ? this.decode(value)
-                : value;
+            var pvalue = dictionary[key];
+            var nvalue = valueMightNeedDecoding ? this.decode(value) : value;
+            dictionary[key] = (pvalue instanceof Array) ? (pvalue[pvalue.length] = nvalue) : (pvalue ? [pvalue, nvalue] : nvalue);
             i = j;
         }
         else if (ch === 59 ||

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cookieparser",
   "description": "cookieparser",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "keywords": [
     "cookie",
     "parse",
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/petkaantonov/cookieparser",
   "repository": {
     "type": "git",
-    "url": "git://github.com/petkaantonov/cookieparser.git"
+    "url": "git://github.com/carlosascari/cookieparser.git"
   },
   "bugs": {
     "url": "http://github.com/petkaantonov/cookieparser/issues"

--- a/test/parse.js
+++ b/test/parse.js
@@ -22,6 +22,12 @@ describe("parse", function() {
         assert.deepEqual({ foo: 'bar', abc: "4" }, cookie.parse('foo=bar; abc=4'));
     });
 
+    specify('basic multiple values with the same name', function() {
+        assert.deepEqual({ foo: 'bar', bar: ['foo', 'foo2'] }, cookie.parse('foo=bar; bar=foo;  bar=foo2'));
+        assert.deepEqual({ foo: '123', bar: ['2', '7'] }, cookie.parse('foo=123; bar=2;  bar=7'));
+        assert.deepEqual({ bar: ['2', '7'] }, cookie.parse('bar=2;bar=7'));
+    });
+
     specify('ignore spaces', function() {
         assert.deepEqual(
             foobar,


### PR DESCRIPTION
The [RFC 6265 spec](http://tools.ietf.org/html/rfc6265#section-4.2.2) does not define how to properly handle duplicate cookies. Currently, *_cookieparser *_ overwrites cookies with the same name, which is faster and it works however, since the ordering of a cookie cannot be relied on (see section 4.2.2), it is entirely possible to to overwrite the latest, or a preferred cookie with a duplicate that may have been set previously, perhaps with a different domain.

I'll elaborate:

A cookie with domain set to:
`example.com`

then another cookie, with domain set to:
`.example.com`

MAY be uniquely identified and stored by a browser (as is the case for most modern browsers), however went sent to the server, and more importantly through _Cookieparser:parse_, only a single cookie can be returned.

The code I included will return an array for duplicate cookies, and regular strings for non-duplicate cookies. Performance was kept in mind. 
